### PR TITLE
Fixed error "IOCTL 0"

### DIFF
--- a/usbdef_linux.go
+++ b/usbdef_linux.go
@@ -63,7 +63,7 @@ const (
 	USBDEVFS_RELEASE    = 0x80045510
 )
 
-const DevBusUsb = "/dev/bus/usb"//"/sys/bus/usb/devices"
+const DevBusUsb = "/dev/bus/usb" //"/sys/bus/usb/devices"
 
 const (
 	UsbDescTypeDevice    = 1


### PR DESCRIPTION
ATM the old behavior is broken: if I don't set `fd` manually then I get infinite error "IOCTL 0". This PR fixes that.